### PR TITLE
Fix metadata version.

### DIFF
--- a/collective/js/timeago/profiles/default/metadata.xml
+++ b/collective/js/timeago/profiles/default/metadata.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>1000</version>
+  <version>1001</version>
 </metadata>


### PR DESCRIPTION
There is an upgrade step upgrading to `1001`, therefore the metadata version must be `1001`, not `1000`.

https://github.com/collective/collective.js.timeago/blob/master/collective/js/timeago/upgrades.zcml#L7
