### PR TITLE
Add locale for fr-ch (French (Switzerland)).

### DIFF
--- a/collective/js/timeago/resources/locales/jquery.timeago.fr-ch.js
+++ b/collective/js/timeago/resources/locales/jquery.timeago.fr-ch.js
@@ -1,0 +1,17 @@
+// French (Switzerland)
+jQuery.timeago.settings.strings = {
+   // environ ~= about, it's optional
+   prefixAgo: "il y a",
+   prefixFromNow: "d'ici",
+   seconds: "moins d'une minute",
+   minute: "environ une minute",
+   minutes: "environ %d minutes",
+   hour: "environ une heure",
+   hours: "environ %d heures",
+   day: "environ un jour",
+   days: "environ %d jours",
+   month: "environ un mois",
+   months: "environ %d mois",
+   year: "un an",
+   years: "%d ans"
+};

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 1.1 (unreleased)
 ----------------
 
+- Add fr-ch locale (French (Switzerland)).
+  [lgraf]
+
 - Added swiss german translations.
   [phgross]
 


### PR DESCRIPTION
This adds a locale definition for `fr-ch` (French, as spoken/written in Switzerland).